### PR TITLE
Allow dir to exist when downloading

### DIFF
--- a/hoss/tools/download.py
+++ b/hoss/tools/download.py
@@ -564,7 +564,7 @@ def _download_worker(work_queue: Queue, status_queue: Queue, dataset: Dataset,
                 ref.read_to(obj_state.path.as_posix())
             else:
                 # If it's a directory and not actually a file, create the directory
-                p.mkdir(parents=True)
+                p.mkdir(parents=True, exist_ok=True)
             obj_state.status = ObjectStatus.EXISTS
 
         except Exception:

--- a/hoss/version.py
+++ b/hoss/version.py
@@ -4,7 +4,7 @@ import requests
 from hoss.error import ServerCheckError
 
 # Set the version of the library here
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 
 
 def get_server_version(server_url: str) -> Tuple[str, str]:


### PR DESCRIPTION
Small PR to fix an issue when you run the same download command multiple times. Directories are now allowed to already exist.

Signed-off-by: Dean Kleissas <dean@gigantum.com>