### PR TITLE
Update default chunk size

### DIFF
--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -53,9 +53,9 @@ Options:
                                   operations.  [default: 10]
   --multipart_threshold INTEGER   Threshold in megabytes for which transfers
                                   will be split into multiple parts, defaults
-                                  to 32MB  [default: 32]
+                                  to 5MB  [default: 5]
   --multipart_chunk_size INTEGER  Size in megabytes for each multipart chunk,
-                                  if used. Defaults to 32MB  [default: 32]
+                                  if used. Defaults to 5MB  [default: 5]
   -m, --metadata TEXT             Object metadata key-value pair(s) applied to
                                   every object uploaded. You may specify
                                   multiple values by repeating the option

--- a/hoss/commands/upload.py
+++ b/hoss/commands/upload.py
@@ -22,10 +22,10 @@ from hoss.tools.upload import upload_directory
                    "have large files, you likely don't need that many because boto will use concurrent uploads")
 @click.option('--max_concurrency', '-c', type=int, default=10, show_default=True,
               help="Maximum number of concurrent s3 API transfer operations.")
-@click.option('--multipart_threshold', type=int, default=32, show_default=True,
-              help="Threshold in megabytes for which transfers will be split into multiple parts, defaults to 32MB")
-@click.option('--multipart_chunk_size', type=int, default=32, show_default=True,
-              help="Size in megabytes for each multipart chunk, if used. Defaults to 32MB")
+@click.option('--multipart_threshold', type=int, default=5, show_default=True,
+              help="Threshold in megabytes for which transfers will be split into multiple parts, defaults to 5MB")
+@click.option('--multipart_chunk_size', type=int, default=5, show_default=True,
+              help="Size in megabytes for each multipart chunk, if used. Defaults to 5MB")
 @click.option('--metadata', '-m', type=str, multiple=True, default=list(),
               help="Object metadata key-value pair(s) applied to every object uploaded."
                    " You may specify multiple values by repeating the option (e.g. -m foo=bar -m fizz=buzz")

--- a/hoss/objectstore.py
+++ b/hoss/objectstore.py
@@ -31,7 +31,10 @@ class ObjectStore(CoreAPI):
 
         # S3 client
         self._client = dict()
-        self._transfer_config = TransferConfig()
+        self._transfer_config = TransferConfig(
+            multipart_chunksize=5*MB,
+            multipart_threshold=5*MB
+        )
         self._sts_credential_expire = None
         self._sts_credential_expire_in_seconds = self.auth.jwt_exp_seconds / 2
 

--- a/hoss/objectstore.py
+++ b/hoss/objectstore.py
@@ -303,14 +303,14 @@ class ObjectStore(CoreAPI):
                                      ExtraArgs={"Metadata": metadata} if metadata is not None else None)
 
     def set_transfer_config(self, multipart_threshold: int, max_concurrency: int,
-                            multipart_chunksize: int = 8*MB) -> None:
+                            multipart_chunksize: int = 5*MB) -> None:
         """Function to set the transfer configuration used in managed transfers.
 
         Args:
             multipart_threshold: The transfer size threshold for which multipart uploads, downloads,
                                  and copies will automatically be triggered.
             max_concurrency: The maximum number of threads that will be making requests to perform a transfer.
-            multipart_chunksize: The partition size of each part for a multipart transfer. (default 8MB)
+            multipart_chunksize: The partition size of each part for a multipart transfer. (default 5MB)
 
         Returns:
 

--- a/hoss/tools/upload.py
+++ b/hoss/tools/upload.py
@@ -39,8 +39,8 @@ nest_asyncio.apply()
 
 
 def upload_directory(dataset_name: str, directory: str, namespace: str, endpoint: str,
-                     skip: str, num_processes: int = 1, max_concurrency: int = 10, multipart_threshold: int = 32,
-                     multipart_chunk_size: int = 32, metadata: Optional[Dict[str, str]] = None,
+                     skip: str, num_processes: int = 1, max_concurrency: int = 10, multipart_threshold: int = 5,
+                     multipart_chunk_size: int = 5, metadata: Optional[Dict[str, str]] = None,
                      prefix: Optional[str] = None) -> None:
     """Function to upload a directory with a CLI interface for status
 

--- a/hoss/utilities.py
+++ b/hoss/utilities.py
@@ -5,7 +5,7 @@ from boto3.s3.transfer import MB
 from hoss.ref import DatasetRef
 
 
-def hash_file(path: str, chunk_size: int = 8 * MB, multipart_threshold: int = 8 * MB) -> str:
+def hash_file(path: str, chunk_size: int = 5 * MB, multipart_threshold: int = 5 * MB) -> str:
     """Utility to hash a file like how S3 etags are generated.
 
     If the file is smaller than or equal to the multipart upload chunk size, it is assumed a single
@@ -17,8 +17,8 @@ def hash_file(path: str, chunk_size: int = 8 * MB, multipart_threshold: int = 8 
 
     Args:
         path: path to the file to hash
-        chunk_size: size in bytes that would be used to chunk a file during a multipart upload (default is 8MB)
-        multipart_threshold: size in bytes that will trigger multipart uploads to be used (default is 8MB)
+        chunk_size: size in bytes that would be used to chunk a file during a multipart upload (default is 5MB)
+        multipart_threshold: size in bytes that will trigger multipart uploads to be used (default is 5MB)
 
     Returns:
         etag formatted hash


### PR DESCRIPTION
Standardize default chunk size and multipart thresholds across the client to match the default values in AWS. Based on the golang AWS sdk [docs](https://docs.aws.amazon.com/sdk-for-go/api/service/s3/s3manager/#DefaultUploadPartSize) the default chunk size is 5 MB. Updated documentation to match the new defaults as well.